### PR TITLE
fix missing header

### DIFF
--- a/pendulum_control/src/pendulum_teleop.cpp
+++ b/pendulum_control/src/pendulum_teleop.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <fstream>
+#include <math.h>
 
 #include "rclcpp/rclcpp.hpp"
 


### PR DESCRIPTION
The use of `M_PI` requires the standard library math.h
